### PR TITLE
Fixes for issue #1

### DIFF
--- a/Install_pensando_tools.sh
+++ b/Install_pensando_tools.sh
@@ -50,8 +50,8 @@
 ELK="TAG=8.16.1"
 elkgitlocation="https://github.com/amd/pensando-elk.git"
 elkbasefolder="pensando-elk"
-brokergitlocation="https://gitlab.com/pensando/tbd/otto/otto-docker.git"
-brokerbasefolder="otto-docker"
+brokergitlocation="https://gitlab.com/pensando/tbd/otto-docker.git"
+brokerbasefolder="apb"
 
 
 rootfolder="pensandotools"

--- a/Install_pensando_tools.sh
+++ b/Install_pensando_tools.sh
@@ -224,6 +224,7 @@ base()
 
 broker()
 {
+	check_rootfolder_permissions
 	cd /$rootfolder/
 	git clone $brokergitlocation
 	sleep 2

--- a/Install_pensando_tools.sh
+++ b/Install_pensando_tools.sh
@@ -150,6 +150,7 @@ check_rootfolder_permissions()
     real_user=$(whoami)
 
 	# Check if the rootfolder exists
+	echo "Checking if $rootfoler exists"
     if [ -d "/$rootfolder" ]; then
         # Check if the directory is writable by the current user
         if [ -w "/$rootfolder" ]; then

--- a/Install_pensando_tools.sh
+++ b/Install_pensando_tools.sh
@@ -50,7 +50,7 @@
 ELK="TAG=8.16.1"
 elkgitlocation="https://github.com/amd/pensando-elk.git"
 elkbasefolder="pensando-elk"
-brokergitlocation="https://gitlab.com/pensando/tbd/otto-docker.git"
+brokergitlocation="https://gitlab.com/pensando/tbd/APB/apb.git"
 brokerbasefolder="apb"
 
 
@@ -200,7 +200,7 @@ broker()
 	git clone $brokergitlocation
 	sleep 2
 	cd $brokerbasefolder/
-	/$rootfolder/$brokerbasefolder/setup_otto
+	/$rootfolder/$brokerbasefolder/setup
 	
 	
 		echo -e "\e[0;31mMake sure you logout and then log back in to make use of the new enviromental variables  \n\e[0m"

--- a/Install_pensando_tools.sh
+++ b/Install_pensando_tools.sh
@@ -180,7 +180,7 @@ base()
 	os=`more /etc/os-release |grep PRETTY_NAME | cut -d  \" -f2 | cut -d " " -f1`
 	if [ "$os" == "Ubuntu" ]; then 
 			updates
-			check_rootfolder_permissions()
+			check_rootfolder_permissions
 			sudo mkdir -p /etc/apt/keyrings
 			sudo  NEEDRESTART_SUSPEND=1 apt-get install curl gnupg ca-certificates lsb-release --yes 
 			sudo mkdir -p /etc/apt/keyrings
@@ -210,7 +210,7 @@ base()
 	elif [ "$os" == "Red" ]; then
 		
 			echo " still to be written 	"
-			check_rootfolder_permissions()
+			check_rootfolder_permissions
 			sudo dnf -y install dnf-plugins-core
 			sudo dnf config-manager --add-repo https://download.docker.com/linux/rhel/docker-ce.repo
 			sudo dnf install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin kcat

--- a/Install_pensando_tools.sh
+++ b/Install_pensando_tools.sh
@@ -233,8 +233,9 @@ broker()
 	/$rootfolder/$brokerbasefolder/setup
 	
 	
-		echo -e "\e[0;31mMake sure you logout and then log back in to make use of the new enviromental variables  \n\e[0m"
-		echo -e "\e[0;31mOnce logged back in, change directory to: \e[1;33m/$rootfolder/$brokerbasefolder/ \e[0;31mThen run the followeing docker command:\n \e[1;33mdocker compose up -d \n\e[0m"			
+		echo -e "\e[0;31mMake sure you logout and then log back in to make use of the new enviroment variables.  \n\e[0m"
+		echo -e "\e[0;31mOnce logged back in, change directory to: \e[1;33m/$rootfolder/$brokerbasefolder/ \e[0;31m\n\n"
+		echo -e "Then run the following docker command:\n \e[1;33mdocker compose up -d \n\e[0m"			
 		
 }
 


### PR DESCRIPTION
This fixes the issue of having the base directory (default of /pensandotools) being created if it doesn't exist and will also check permissions on it even if it does exist.  

Added the following functions:
- create_rootfolder()
   Creates the root folder designated in the installer script variable at the top of the script.  Also checks user permissions when creating and sets them appropriately

- check_rootfolder_permissions()
  Checks the permissions on the root folder if it exists.  If it doesn't exist, it calls create_rootfolder().  If it does exist but permissions aren't set properly, it fixes that as well.

Added in call to check_rootfolder_permissions() in base install.  The call will create the root folder if it doesn't exist.

This solves issue #1 


This also contains changes from otto to apb for naming purposes as the broker goes public. 
